### PR TITLE
Correct error message for invalid signatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ impl<S> FromRequestParts<S> for SignedUrl {
         let unsigned_url = format!("{}{}", url.path(), stringify_query(&query));
 
         if signature != hmac_sha256(&unsigned_url).unwrap() {
-            return Err((StatusCode::UNAUTHORIZED, "Missing signature"));
+            return Err((StatusCode::UNAUTHORIZED, "Invalid signature"));
         }
 
         Ok(SignedUrl)


### PR DESCRIPTION
With this PR, providing an incorrect signature as the query parameter will give an "Invalid signature" error instead of a "Missing signature" one

(thanks for noticing, @kymppi!)